### PR TITLE
Handle an existing session token

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,10 @@ This is a small Bash script that gives the user the ability to quickly
 obtain AWS session credentials as shell environment variables, using
 heavily restricted IAM access keys and a MFA device.
 
-For example, a user might have a Deny policy as detailed here:
-https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage-mfa-only.html
+For example, a user might have a policy applied to deny nearly any
+service access until the user has enabled MFA, as described by Amazon
+`here
+<https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage-mfa-only.html>`__.
 
 
 Project page
@@ -34,9 +36,10 @@ Requirements
 .. _GNU grep: https://www.gnu.org/software/grep/
 .. _jq: https://jqlang.github.io/jq/
 
-These are the dependencies that were tested, and all but AWS Command
-Line Interface should be available in almost any desktop or server
-GNU/Linux distribution's package management system.
+These are the dependencies that were tested, and all with the possible
+exception of the AWS Command Line Interface (AWS CLI) should be
+available in almost any desktop or server GNU/Linux distribution's
+package management system.
 
 
 Setup
@@ -92,3 +95,13 @@ free to open an issue on GitHub, however please be patent with a
 response.
 
 Likewise, pull requests are also welcome.
+
+
+
+Related
+=======
+
+If you like this project, you might also find `envswitch`_
+useful. These are both stand-alone tools but work very well together.
+
+.. _envswitch: https://github.com/sitepoint/envswitch

--- a/bin/aws-mfa-env
+++ b/bin/aws-mfa-env
@@ -9,10 +9,10 @@ function __aws_mfa_pre_exec_checks()
     if [ -z "${AWS_MFA_ARN}" ]
     then
         {
-            echo "Please set the AWS_MFA_ARN environment variable to your "
+            echo "Please set the AWS_MFA_ARN environment variable to your"
             echo "MFA identifier."
             echo
-            echo "You can find this information on your IAM user page under "
+            echo "You can find this information on your IAM user page under"
             echo "the \`Security credentials\` tab, with the format:"
             echo "arn:aws:iam::<AWS ACCOUNT>:mfa/<IAM USER>"
         } 1>&2
@@ -31,6 +31,19 @@ function __aws_mfa_pre_exec_checks()
     if [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ]
     then
         echo "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are not set!" 1>&2
+        return 1
+    fi
+
+    if [ -n "${AWS_SESSION_TOKEN}" ]
+    then
+        {
+            echo "AWS_SESSION_TOKEN is already set!"
+            echo
+            echo "If your MFA session has expired, please unset"
+            echo "AWS_SESSION_TOKEN and reset AWS_ACCESS_KEY_ID and"
+            echo "AWS_SECRET_ACCESS_KEY to your normal IAM account access key"
+            echo "values."
+        } 1>&2
         return 1
     fi
 }


### PR DESCRIPTION
## Card
None

## Description
Warns of a potential issue running `aws-mfa-env` when the `AWS_SESSION_TOKEN` environment variable already exists. This could happen because the user attempted to sign back in using MFA after a prior session had expired, but may not have reset the necessary environment variables.

## Demo

Using an [envswtich](https://github.com/sitepoint/envswitch) profile:
```
(aws-myawsaccount-us-west-2) $ aws-mfa-env 
AWS_SESSION_TOKEN is already set!

If your MFA session has expired, please unset
AWS_SESSION_TOKEN and reset AWS_ACCESS_KEY_ID and
AWS_SECRET_ACCESS_KEY to your normal IAM account access key
values.
(aws-myawsaccount-us-west-2) $ aws-myawsaccount-us-west-2 
(aws-myawsaccount-us-west-2) $ aws-mfa-env 
MFA token: 531023
Success!
Expiration: "2025-06-25T13:58:40+00:00"
(aws-myawsaccount-us-west-2) $ 
```